### PR TITLE
Lower minSdkVersion to support IceCreamSandwich and newer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
 	defaultConfig {
 		applicationId "de.christinecoenen.code.zapp"
-		minSdkVersion 21
+		minSdkVersion 14
 		targetSdkVersion 23
 		versionCode 2
 		versionName "0.2.0"

--- a/programguide/build.gradle
+++ b/programguide/build.gradle
@@ -5,7 +5,7 @@ android {
 	buildToolsVersion "24.0.2"
 
 	defaultConfig {
-		minSdkVersion 21
+		minSdkVersion 14
 		targetSdkVersion 24
 		versionCode 1
 		versionName "1.0"


### PR DESCRIPTION
My tablet (Nexus 7 2012) is running KitKat, so i tried to lower the minimum SDK version needed.
Found that we can go down to `ICE_CREAM_SANDWICH` (even `HONEYCOMB_MR2`), so i lowered the `minSdkVersion` setting.