### PR TITLE
Fix channel ARD HD/Das Erste HD URL changed

### DIFF
--- a/app/src/main/res/raw/channels.json
+++ b/app/src/main/res/raw/channels.json
@@ -2,7 +2,7 @@
   {
 	"id": "das_erste",
 	"name": "Das Erste",
-	"stream_url": "https://daserstehdde-lh.akamaihd.net/i/daserstehd_de@629196/index_3776_av-p.m3u8",
+	"stream_url": "https://mcdn.daserste.de/daserste/de/master_3744.m3u8",
 	"logo_name": "channel_logo_das_erste",
 	"color": "#001A4B"
   },


### PR DESCRIPTION
The channel Das Erste HD don't work anymore. Url has changed. ZDF HD is shown with Moma Magazin dated 06.05.19 I think.
Old: http://daserste_live-lh.akamaihd.net/i/daserste_de@91204/master.m3u8
New:  https://mcdn.daserste.de/daserste/de/master_3744.m3u8